### PR TITLE
Add aws credentials volume for docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ _Note_: make sure to add the execution permission to Komiser `chmod +x komiser`
 ### Docker:
 
 ```
-docker run -d -p 3000:3000 --name komiser mlabouardy/komiser:2.0.0
+docker run -d -p 3000:3000 -v $HOME/.aws/credentials:/root/.aws/credentials --name komiser mlabouardy/komiser:2.0.0
 ```
 
 ## How to use


### PR DESCRIPTION
### Description

Add volume mount to user's aws credentials for `docker run` example

### Related Issue

N/A

### Changes proposed 

See diff.

### Screenshots
