### PR TITLE
fix error 'can't create /root/.aws/credentials: nonexistent directory…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ENV DURATION 30
 RUN apk update && apk add curl
 RUN curl -L https://s3.us-east-1.amazonaws.com/komiser/$VERSION/linux/komiser -o /usr/bin/komiser && \
     chmod +x /usr/bin/komiser && \
-    mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+    mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    mkdir ~/.aws && touch ~/.aws/credentials
 
 EXPOSE $PORT
 ENTRYPOINT komiser start --port $PORT

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ _Note_: make sure to add the execution permission to Komiser `chmod +x komiser`
 
 ### Docker:
 
+make sure your .aws directory exist in your system, if not, create one;
+```
+mkdir ~/.aws
+touch ~/.aws/credentials
+vi ~/.aws/credentials
+```
+add Access Key ID and Secret Access Key to ~/.aws/credentials using this format:
+```
+[default]
+aws_access_key_id = <access key id>
+aws_secret_access_key = <secret access key>
+region = <AWS region>
 ```
 docker run -d -p 3000:3000 --name komiser mlabouardy/komiser:2.1.0
 ```


### PR DESCRIPTION
…' in docker environment

### Description
Fix error "can't create /root/.aws/credentials: nonexistent directory" when I`m try to set  ~/.aws/credentials in docer container envierment.

### Related Issue

### Changes proposed 
create folder in docker file 'RUN' section
### Screenshots
