### PR TITLE
Enabled 404 on Static File Serve

### DIFF
--- a/interceptResponseWriter.go
+++ b/interceptResponseWriter.go
@@ -1,0 +1,25 @@
+package main
+
+import "net/http"
+
+type interceptResponseWriter struct {
+	http.ResponseWriter
+	errH func(http.ResponseWriter, int)
+}
+
+func (w *interceptResponseWriter) WriteHeader(status int) {
+	if status >= http.StatusBadRequest {
+		w.errH(w.ResponseWriter, status)
+		w.errH = nil
+	} else {
+		w.ResponseWriter.WriteHeader(status)
+	}
+}
+
+func (w *interceptResponseWriter) Write(p []byte) (n int, err error) {
+	if w.errH == nil {
+		return len(p), nil
+	}
+	return w.ResponseWriter.Write(p)
+}
+


### PR DESCRIPTION
## Description
Current if you link directly to /compute the static file server will return a 404 because there is not compute file in assetsFS. I have created an interceptor to handle the 404s on FileServer.

## Related Issue
## Changes proposed
Add a interceptor to catch the 404 on http.FileServer

## Screenshots
