### PR TITLE
Aws Policy Location Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker run -d -p 3000:3000 -e AWS_ACCESS_KEY_ID="" -e AWS_SECRET_ACCESS_KEY="" -
 * Create an IAM user with the following IAM [policy](https://raw.githubusercontent.com/mlabouardy/komiser/master/policy.json):
 
 ```
-wget https://komiser.s3.amazonaws.com/policy.json
+wget [https://raw.githubusercontent.com/mlabouardy/komiser/master/policy.json]
 ```
 
 * Add your **Access Key ID** and **Secret Access Key** to *~/.aws/credentials* using this format

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker run -d -p 3000:3000 -e AWS_ACCESS_KEY_ID="" -e AWS_SECRET_ACCESS_KEY="" -
 * Create an IAM user with the following IAM [policy](https://raw.githubusercontent.com/mlabouardy/komiser/master/policy.json):
 
 ```
-wget [https://raw.githubusercontent.com/mlabouardy/komiser/master/policy.json]
+wget https://raw.githubusercontent.com/mlabouardy/komiser/master/policy.json
 ```
 
 * Add your **Access Key ID** and **Secret Access Key** to *~/.aws/credentials* using this format


### PR DESCRIPTION
### Description

Currently the bucket @ https://komiser.s3.amazonaws.com is unavailable. This creates confusion for new people pulling the policy down. I would suggest just pointing it to the policy in the master branch.

### Related Issue

Non

### Changes proposed 

Change the wget for the AWS policy to point directly to the github static file. 

### Screenshots
