### PR TITLE
ci: run on avrea-ubuntu-latest-4-vcpu (like-for-like with ubuntu-latest)

### DIFF
--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   build_test_dashboard:
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: avrea-ubuntu-latest-8-vcpu
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +26,7 @@ jobs:
         working-directory: dashboard
 
   build_test_cli:
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: avrea-ubuntu-latest-8-vcpu
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   build_test_dashboard:
-    runs-on: avrea-ubuntu-latest-2-vcpu
+    runs-on: avrea-ubuntu-latest-4-vcpu
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +26,7 @@ jobs:
         working-directory: dashboard
 
   build_test_cli:
-    runs-on: avrea-ubuntu-latest-2-vcpu
+    runs-on: avrea-ubuntu-latest-4-vcpu
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   build_test_dashboard:
-    runs-on: avrea-ubuntu-latest-8-vcpu
+    runs-on: avrea-ubuntu-latest-4-vcpu
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +26,7 @@ jobs:
         working-directory: dashboard
 
   build_test_cli:
-    runs-on: avrea-ubuntu-latest-8-vcpu
+    runs-on: avrea-ubuntu-latest-4-vcpu
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Follow-up to #1635. GitHub's ubuntu-latest is 4 vCPU / 16 GB; the auto-generated PR used the 2 vCPU Avrea size. This moves both jobs to avrea-ubuntu-latest-4-vcpu so the timing comparison is fair.