### PR TITLE
[do not merge] GitHub-hosted baseline run for the Avrea comparison

### DIFF
--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   build_test_dashboard:
-    runs-on: avrea-ubuntu-latest-2-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +26,7 @@ jobs:
         working-directory: dashboard
 
   build_test_cli:
-    runs-on: avrea-ubuntu-latest-2-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Temporary control: same workflow on ubuntu-latest, run cold and then warm, so the Avrea numbers have a fair baseline. Close after the runs.